### PR TITLE
fix: saltar cuando no existe contrapartida

### DIFF
--- a/Controller/Modelo111.php
+++ b/Controller/Modelo111.php
@@ -275,6 +275,11 @@ class Modelo111 extends Controller
             $recipients[$codcontrapartida] = $codcontrapartida;
             $this->retencionesPracticadas += $line->haber;
 
+            // si no existe la contrapartida saltar
+            if (empty($codcontrapartida)) {
+                continue;
+            }
+
             // inicializar perceptor si no existe
             $this->initRecipient($codcontrapartida);
 
@@ -295,6 +300,11 @@ class Modelo111 extends Controller
         foreach ($this->baseLines as $line) {
             $codcontrapartida = $line->codcontrapartida;
             $this->baseRetenciones += $line->debe;
+
+            // si no existe la contrapartida saltar
+            if (empty($codcontrapartida)) {
+                continue;
+            }
 
             // inicializar perceptor si no existe
             $this->initRecipient($codcontrapartida);


### PR DESCRIPTION
Solución a este error de forja: https://facturascripts.com/issues/109-874-741

Ha veces "contrapartida" es null, así que se ha implementado saltar la iteración para evitar ese error.

Función NO testada, hay que probar que no genera efectos secundarios en el código, no he podido probarlo porque no me ha querido funcionar el plugin y no creo que sea un bug tampoco.