### PR TITLE
añadir opciones de descarga y total debe y haber

### DIFF
--- a/Controller/Modelo111.php
+++ b/Controller/Modelo111.php
@@ -96,6 +96,120 @@ class Modelo111 extends Controller
         if ($action === 'download') {
             $this->downloadFile($response);
         }
+        if ($action === 'download-csv') {
+            $this->downloadCsv($response);
+        }
+        if ($action === 'download-xlsx') {
+            $this->downloadXlsx($response);
+        }
+    }
+
+    protected function downloadCsv(&$response): void
+    {
+        if (empty($this->result['entryLines'])) {
+            Tools::log()->warning('no-data');
+            return;
+        }
+
+        $year = date('Y', strtotime($this->result['exercise']->fechainicio));
+        $periodo = $this->getPeriodNumber();
+        $filename = 'modelo111_' . $year . '_' . $periodo . '.csv';
+
+        $rows = [];
+        $rows[] = implode(';', [
+            Tools::lang()->trans('accounting-entry'),
+            Tools::lang()->trans('subaccount'),
+            Tools::lang()->trans('counterpart'),
+            Tools::lang()->trans('concept'),
+            Tools::lang()->trans('debit'),
+            Tools::lang()->trans('credit'),
+            Tools::lang()->trans('date'),
+        ]);
+        foreach ($this->result['entryLines'] as $line) {
+            $rows[] = implode(';', [
+                $line->numero,
+                $line->codsubcuenta,
+                $line->codcontrapartida,
+                '"' . str_replace('"', '""', strip_tags($line->concepto)) . '"',
+                number_format($line->debe, 2, ',', ''),
+                number_format($line->haber, 2, ',', ''),
+                $line->fecha,
+            ]);
+        }
+        // fila de totales
+        $rows[] = implode(';', [
+            '',
+            '',
+            '',
+            Tools::lang()->trans('total'),
+            number_format($this->result['totalDebe'], 2, ',', ''),
+            number_format($this->result['totalHaber'], 2, ',', ''),
+            '',
+        ]);
+
+        $content = implode("\n", $rows);
+
+        $response->headers->set('Content-Type', 'text/csv; charset=UTF-8');
+        $response->headers->set('Content-Disposition', 'attachment; filename="' . $filename . '"');
+        $response->setContent("\xEF\xBB\xBF" . $content); // BOM UTF-8 para Excel
+        $response->send();
+        exit;
+    }
+
+    protected function downloadXlsx(&$response): void
+    {
+        if (empty($this->result['entryLines'])) {
+            Tools::log()->warning('no-data');
+            return;
+        }
+
+        $year = date('Y', strtotime($this->result['exercise']->fechainicio));
+        $periodo = $this->getPeriodNumber();
+        $filename = 'modelo111_' . $year . '_' . $periodo . '.xlsx';
+
+        $writer = new \XLSXWriter();
+        $writer->setAuthor('FacturaScripts');
+        $writer->setTitle('Modelo 111');
+
+        $sheetName = 'Modelo 111';
+        $headers = [
+            Tools::lang()->trans('accounting-entry') => 'string',
+            Tools::lang()->trans('subaccount') => 'string',
+            Tools::lang()->trans('counterpart') => 'string',
+            Tools::lang()->trans('concept') => 'string',
+            Tools::lang()->trans('debit') => 'price',
+            Tools::lang()->trans('credit') => 'price',
+            Tools::lang()->trans('date') => 'string',
+        ];
+        $writer->writeSheetHeader($sheetName, $headers);
+
+        foreach ($this->result['entryLines'] as $line) {
+            $writer->writeSheetRow($sheetName, [
+                $line->numero,
+                $line->codsubcuenta,
+                $line->codcontrapartida,
+                strip_tags($line->concepto),
+                $line->debe,
+                $line->haber,
+                $line->fecha,
+            ]);
+        }
+
+        $writer->writeSheetRow($sheetName, [
+            '',
+            '',
+            '',
+            Tools::lang()->trans('total'),
+            $this->result['totalDebe'],
+            $this->result['totalHaber'],
+            '',
+        ]);
+
+        $response->headers->set('Content-Type', 'application/octet-stream');
+        $response->headers->set('Content-Disposition', 'attachment; filename="' . $filename . '"');
+        $response->setContent($writer->writeToString());
+        $response->send();
+        exit;
     }
 
     protected function getCurrentPeriod(): string

--- a/Lib/Modelo111.php
+++ b/Lib/Modelo111.php
@@ -69,7 +69,13 @@ class Modelo111
 
     /** @var float */
     protected static $retencionesPracticadas = 0.0;
-    
+
+    /** @var float */
+    protected static $totalDebe = 0.0;
+
+    /** @var float */
+    protected static $totalHaber = 0.0;
+
     /** @var float */
     protected static $totalIngresar = 0.0;
 
@@ -108,6 +114,8 @@ class Modelo111
             'ingresosPeriodoAnterior' => static::$ingresosPeriodoAnterior,
             'numRecipients' => static::$numRecipients,
             'recipientDetails' => static::$recipientDetails,
+            'totalDebe' => static::$totalDebe,
+            'totalHaber' => static::$totalHaber,
             'totalIngresar' => static::$totalIngresar,
         ];
     }
@@ -288,6 +296,14 @@ class Modelo111
 
             // sumar base de sueldos
             static::$recipientDetails[$codcontrapartida]['base'] += $line->debe;
+        }
+
+        // calcular totales debe/haber de entryLines
+        static::$totalDebe = 0.0;
+        static::$totalHaber = 0.0;
+        foreach (static::$entryLines as $line) {
+            static::$totalDebe += $line->debe;
+            static::$totalHaber += $line->haber;
         }
 
         static::$numRecipients = count($recipients);

--- a/Translation/es_ES.json
+++ b/Translation/es_ES.json
@@ -1,5 +1,7 @@
 {
     "annual-190": "Anual (Modelo 190)",
+    "download-csv": "Descargar CSV",
+    "download-xlsx": "Descargar Excel",
     "model-111": "Modelo 111",
     "model-111-190": "Modelos 111 y 190",
     "model-111-p": "El Modelo 111 es una declaración trimestral de las retenciones del IRPF practicadas a trabajadores, profesionales y empresarios.",

--- a/View/Modelo111.html.twig
+++ b/View/Modelo111.html.twig
@@ -52,9 +52,32 @@
                             <i class="fa-solid fa-eye me-1"></i> {{ trans('preview') }}
                         </button>
                         {% if fsc.result.entryLines is not empty %}
-                            <button type="submit" name="action" value="download" class="btn btn-success ms-2">
-                                <i class="fa-solid fa-download me-1"></i> {{ trans('download') }}
-                            </button>
+                            <div class="btn-group ms-2">
+                                <button type="button" class="btn btn-success dropdown-toggle"
+                                        data-bs-toggle="dropdown" aria-expanded="false">
+                                    <i class="fa-solid fa-download me-1"></i> {{ trans('download') }}
+                                </button>
+                                <ul class="dropdown-menu">
+                                    <li>
+                                        <button type="submit" name="action" value="download"
+                                                class="dropdown-item">
+                                            <i class="fa-solid fa-file me-1"></i> {{ trans('download') }} (.111)
+                                        </button>
+                                    </li>
+                                    <li>
+                                        <button type="submit" name="action" value="download-xlsx"
+                                                class="dropdown-item">
+                                            <i class="fa-solid fa-file-excel me-1"></i> {{ trans('download-xlsx') }}
+                                        </button>
+                                    </li>
+                                    <li>
+                                        <button type="submit" name="action" value="download-csv"
+                                                class="dropdown-item">
+                                            <i class="fa-solid fa-file-csv me-1"></i> {{ trans('download-csv') }}
+                                        </button>
+                                    </li>
+                                </ul>
+                            </div>
                         {% endif %}
                     </div>
                 </div>
@@ -221,6 +244,14 @@
                                             </tr>
                                         {% endfor %}
                                         </tbody>
+                                        <tfoot>
+                                        <tr class="table-active fw-bold">
+                                            <td colspan="4">{{ trans('total') }}</td>
+                                            <td class="text-end">{{ money(fsc.result.totalDebe) }}</td>
+                                            <td class="text-end">{{ money(fsc.result.totalHaber) }}</td>
+                                            <td></td>
+                                        </tr>
+                                        </tfoot>
                                     </table>
                                 </div>
                             </div>


### PR DESCRIPTION
https://facturascripts.com/roadmap/2633
- Se ha implementado un menú desplegable para las opciones de descarga en el archivo Modelo111.html.twig, permitiendo descargar en formatos .111, CSV y XLSX.
- Se han añadido métodos para manejar la descarga de archivos CSV y XLSX en Modelo111.php.
- Se han agregado las traducciones correspondientes en es_ES.json para las nuevas opciones de descarga.
- Se han calculado y mostrado los totales de debe y haber en la tabla de resultados.

Este cambio mejora la funcionalidad de exportación de datos en el modelo 111.